### PR TITLE
Fix `boot` resource

### DIFF
--- a/hetznerrobot/client_boot.go
+++ b/hetznerrobot/client_boot.go
@@ -73,7 +73,7 @@ func (c *HetznerRobotClient) setBootProfile(serverID int, activeBootProfile stri
 	encodedParams := formParams.Encode()
 	log.Println(encodedParams)
 
-	bytes, err := c.makeAPICall("POST", fmt.Sprintf("%s/boot/%s/%d", c.url, activeBootProfile, serverID), strings.NewReader(encodedParams), http.StatusAccepted)
+	bytes, err := c.makeAPICall("POST", fmt.Sprintf("%s/boot/%d/%s", c.url, serverID, activeBootProfile), strings.NewReader(encodedParams), http.StatusAccepted)
 	if err != nil {
 		return nil, err
 	}

--- a/hetznerrobot/client_boot.go
+++ b/hetznerrobot/client_boot.go
@@ -60,7 +60,9 @@ func (c *HetznerRobotClient) getBoot(serverID int) (*BootProfile, error) {
 func (c *HetznerRobotClient) setBootProfile(serverID int, activeBootProfile string, arch string, os string, lang string, authorizedKeys []string) (*BootProfile, error) {
 	formParams := url.Values{}
 	formParams.Set("arch", arch)
-	formParams.Set("authorized_key", authorizedKeys[0])
+	for _, key := range authorizedKeys {
+		formParams.Add("authorized_key", key)
+	}
 	if activeBootProfile == "linux" {
 		formParams.Set("dist", os)
 		formParams.Set("lang", lang)

--- a/hetznerrobot/client_boot.go
+++ b/hetznerrobot/client_boot.go
@@ -73,8 +73,11 @@ func (c *HetznerRobotClient) setBootProfile(serverID int, activeBootProfile stri
 	encodedParams := formParams.Encode()
 	log.Println(encodedParams)
 
-	bytes, err := c.makeAPICall("POST", fmt.Sprintf("%s/boot/%d/%s", c.url, serverID, activeBootProfile), strings.NewReader(encodedParams), http.StatusAccepted)
+	bytes, err := c.makeAPICall("POST", fmt.Sprintf("%s/boot/%d/%s", c.url, serverID, activeBootProfile), strings.NewReader(encodedParams), http.StatusOK)
 	if err != nil {
+		if strings.Contains(err.Error(), "BOOT_ALREADY_ENABLED") {
+			return c.getBoot(serverID)
+		}
 		return nil, err
 	}
 

--- a/hetznerrobot/resource_boot.go
+++ b/hetznerrobot/resource_boot.go
@@ -47,9 +47,11 @@ func resourceBoot() *schema.Resource {
 			},
 			"authorized_keys": {
 				Type:        schema.TypeList,
-				Elem:        schema.TypeString,
 				Optional:    true,
 				Description: "One or more SSH key fingerprints",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 			},
 			// read-only / computed
 			"ipv4_address": {
@@ -106,7 +108,9 @@ func resourceBootCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	lang := d.Get("language").(string)
 	authorizedKeys := make([]string, 0)
 	if input := d.Get("authorized_keys"); input != nil {
-		authorizedKeys = input.([]string)
+		for _, key := range input.([]interface{}) {
+			authorizedKeys = append(authorizedKeys, key.(string))
+		}
 	}
 
 	bootProfile, err := c.setBootProfile(serverID, activeBootProfile, arch, os, lang, authorizedKeys)
@@ -157,7 +161,12 @@ func resourceBootUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	arch := d.Get("architecture").(string)
 	os := d.Get("operating_system").(string)
 	lang := d.Get("language").(string)
-	authorizedKeys := d.Get("authorized_keys").([]string)
+	authorizedKeys := make([]string, 0)
+	if input := d.Get("authorized_keys"); input != nil {
+		for _, key := range input.([]interface{}) {
+			authorizedKeys = append(authorizedKeys, key.(string))
+		}
+	}
 
 	bootProfile, err := c.setBootProfile(serverID, activeBootProfile, arch, os, lang, authorizedKeys)
 	if err != nil {

--- a/hetznerrobot/resource_boot.go
+++ b/hetznerrobot/resource_boot.go
@@ -45,6 +45,12 @@ func resourceBoot() *schema.Resource {
 				Optional:    true,
 				Description: "Active Operating System / Distribution",
 			},
+			"authorized_keys": {
+				Type:        schema.TypeList,
+				Elem:        schema.TypeString,
+				Optional:    true,
+				Description: "One or more SSH key fingerprints",
+			},
 			// read-only / computed
 			"ipv4_address": {
 				Type:        schema.TypeString,
@@ -98,7 +104,10 @@ func resourceBootCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	arch := d.Get("architecture").(string)
 	os := d.Get("operating_system").(string)
 	lang := d.Get("language").(string)
-	authorizedKeys := d.Get("authorized_keys").([]string)
+	authorizedKeys := make([]string, 0)
+	if input := d.Get("authorized_keys"); input != nil {
+		authorizedKeys = input.([]string)
+	}
 
 	bootProfile, err := c.setBootProfile(serverID, activeBootProfile, arch, os, lang, authorizedKeys)
 	if err != nil {


### PR DESCRIPTION
## Synopsis

At the moment the `boot` resource is not working at all, panicking with:
```
╷
│ Error: Request cancelled
│ 
│   with module.cluster.hetzner-robot_boot.node["bulwark.node"],
│   on modules/cluster/hetzner-robot.tf line 7, in resource "hetzner-robot_boot" "node":
│    7: resource "hetzner-robot_boot" "node" {
│ 
│ The plugin.(*GRPCProvider).ApplyResourceChange request was cancelled.
╵

Stack trace from the terraform-provider-hetzner-robot_v0.1.7 plugin:

panic: interface conversion: interface {} is nil, not []string

goroutine 36 [running]:
github.com/peters-it/terraform-provider-hetzner-robot/hetznerrobot.resourceBootCreate({0xca40e0, 0xc00043fec0}, 0xc00012b2d8, {0xb2dc40, 0xc0003ffd10})
        github.com/peters-it/terraform-provider-hetzner-robot/hetznerrobot/resource_boot.go:101 +0x3fe
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0xc0000ca8c0, {0xca40e0, 0xc00043fec0}, 0xd, {0xb2dc40, 0xc0003ffd10})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.13.0/helper/schema/resource.go:708 +0x12e
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc0000ca8c0, {0xca40e0, 0xc00043fec0}, 0xc000450750, 0xc000433580, {0xb2dc40, 0xc0003ffd10})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.13.0/helper/schema/resource.go:838 +0x9ba
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc0002f0318, {0xca4038, 0xc000452300}, 0xc00044c550)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.13.0/helper/schema/grpc_provider.go:1021 +0xe3c
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0xc0001bc6e0, {0xca40e0, 0xc00043f620}, 0xc000409f10)
        github.com/hashicorp/terraform-plugin-go@v0.8.0/tfprotov5/tf5server/server.go:812 +0x56b
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0xb7c200, 0xc0001bc6e0}, {0xca40e0, 0xc00043f620}, 0xc0004386c0, 0x0)
        github.com/hashicorp/terraform-plugin-go@v0.8.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:385 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0001fe8c0, {0xcb0d98, 0xc0001d1520}, 0xc00042f200, 0xc0002e1e60, 0x1160740, 0x0)
        google.golang.org/grpc@v1.45.0/server.go:1282 +0xccf
google.golang.org/grpc.(*Server).handleStream(0xc0001fe8c0, {0xcb0d98, 0xc0001d1520}, 0xc00042f200, 0x0)
        google.golang.org/grpc@v1.45.0/server.go:1619 +0xa2a
google.golang.org/grpc.(*Server).serveStreams.func1.2()
        google.golang.org/grpc@v1.45.0/server.go:921 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
        google.golang.org/grpc@v1.45.0/server.go:919 +0x294

Error: The terraform-provider-hetzner-robot_v0.1.7 plugin crashed!
```

This is due to [trying consuming undefined `authorized_keys` input argument](https://github.com/Peters-IT/terraform-provider-hetzner-robot/blob/v0.1.7/hetznerrobot/resource_boot.go#L101).

If we do specify this input argument in HCL manifest, we'll meet another hard error:
```
╷
│ Error: Unsupported argument
│ 
│   on modules/cluster/hetzner-robot.tf line 13, in resource "hetzner-robot_boot" "node":
│   13:   authorized_keys = []
│ 
│ An argument named "authorized_keys" is not expected here.
╵
```

## Solution

This PR adds `authorized_keys` input argument and correctly bypasses it to the Robot API request.